### PR TITLE
Python typed/packed parameters highlighting

### DIFF
--- a/lua/hlargs/util.lua
+++ b/lua/hlargs/util.lua
@@ -4,7 +4,7 @@ local ts_utils = require 'nvim-treesitter.ts_utils'
 
 local ignored_field_names = {
   python = {
-    _ = { 'attribute' }
+    _ = { 'attribute', 'name' }
   },
   lua = {
     dot_index_expression = { 'field' },

--- a/queries/python/function_arguments.scm
+++ b/queries/python/function_arguments.scm
@@ -1,7 +1,29 @@
 (function_definition
   parameters: (parameters
-    (identifier) @argname))
+    [
+      (identifier) @argname
+      (list_splat_pattern
+        (identifier) @argname)
+      (dictionary_splat_pattern
+        (identifier) @argname)
+    ]))
+(function_definition
+  parameters: (parameters
+    (typed_parameter
+      [
+        (identifier) @argname
+        (list_splat_pattern
+          (identifier) @argname)
+        (dictionary_splat_pattern
+          (identifier) @argname)
+      ])))
 (lambda
   parameters: (lambda_parameters
-    (identifier) @argname))
+    [
+      (identifier) @argname
+      (list_splat_pattern
+        (identifier) @argname)
+      (dictionary_splat_pattern
+        (identifier) @argname)
+    ]))
 

--- a/testfiles/test.py
+++ b/testfiles/test.py
@@ -1,12 +1,42 @@
 class Class:
-  def __init__(self, arg1, arg2):
-    self.arg1 = arg1
-    self.arg2 = arg2
-    def function2(arg3): # inner function
-        return arg2
+    def __init__(self, arg1, arg2):
+        self.arg1 = arg1
+        self.arg2 = arg2
+
+        def function2(arg3):  # inner function
+            return arg2
+
 
 var = 10
+
+
 def fn(arg4):
     global var
-    Class(arg4, lambda x: x+arg4+var)
+    Class(arg4, lambda x: x + arg4 + var)
 
+
+def fn_typed(arg5: dict[int, str]) -> None:
+    if arg5 == var:
+        fn_splat_list("", "", "")
+    else:
+        fn_splat_dict(arg8=var, param=arg5, arg5=arg5)
+
+
+def fn_splat_list(arg6, *arg7) -> None:
+    if arg7 == [var]:
+        Class(arg6, lambda *args: args == [var, 15])
+
+
+def fn_typed_splat_list(arg6: int, *arg7: list[str]) -> None:
+    if arg7 == []:
+        Class(arg6, lambda *args: args == [var, 25])
+
+
+def fn_splat_dict(arg8, **arg9) -> None:
+    if arg9 == {}:
+        Class(arg8, lambda **kwargs: kwargs == {var: "var"})
+
+
+def fn_typed_splat_dict(arg10: int, **arg11: dict[int, str]) -> None:
+    if arg11 == {}:
+        Class(arg10, lambda **kwargs: kwargs == {var: "var"})


### PR DESCRIPTION
This PR resolves #3 and adds support for typed and packed parameters highlighting for Python:

|testfiles/test.py (Original highlighting)| testfiles/test.py (This PR)|
:-------:| :-----:|
![image](https://user-images.githubusercontent.com/44975313/153896446-48bbb98d-528c-4fdd-908b-0528fd738dea.png) |![image](https://user-images.githubusercontent.com/44975313/153896513-792ddd10-fcce-4a9e-a27d-7f19a57538ce.png)
