### PR TITLE
fix: use highlight if absent

### DIFF
--- a/lua/hlargs/config.lua
+++ b/lua/hlargs/config.lua
@@ -27,12 +27,9 @@ local defaults = {
   }
 }
 
-local hl_group = "Hlargs"
-
 function M.setup(opts)
   M.opts = vim.tbl_deep_extend("force", {}, defaults, opts or {})
-  vim.cmd("highlight clear " .. hl_group)
-  vim.cmd("highlight! def " .. hl_group .. " guifg=" .. M.opts.color)
+  vim.cmd("highlight def Hlargs guifg=" .. M.opts.color)
 end
 
 M.setup()

--- a/lua/hlargs/config.lua
+++ b/lua/hlargs/config.lua
@@ -32,7 +32,5 @@ function M.setup(opts)
   vim.cmd("highlight def Hlargs guifg=" .. M.opts.color)
 end
 
-M.setup()
-
 return M
 


### PR DESCRIPTION
The users' highlight group shouldn't be ignored.