### PR TITLE
[python] Add support for arguments with default values

### DIFF
--- a/queries/python/function_arguments.scm
+++ b/queries/python/function_arguments.scm
@@ -7,9 +7,7 @@
       (dictionary_splat_pattern
         (identifier) @argname)
       (default_parameter
-        [
-          (identifier) @argname
-        ])
+        (identifier) @argname)
       (typed_parameter
         [
           (identifier) @argname
@@ -19,9 +17,7 @@
             (identifier) @argname)
         ])
       (typed_default_parameter
-        [
-          (identifier) @argname
-        ])
+        (identifier) @argname)
     ]))
 (lambda
   parameters: (lambda_parameters

--- a/queries/python/function_arguments.scm
+++ b/queries/python/function_arguments.scm
@@ -6,29 +6,23 @@
         (identifier) @argname)
       (dictionary_splat_pattern
         (identifier) @argname)
+      (default_parameter
+        [
+          (identifier) @argname
+        ])
+      (typed_parameter
+        [
+          (identifier) @argname
+          (list_splat_pattern
+            (identifier) @argname)
+          (dictionary_splat_pattern
+            (identifier) @argname)
+        ])
+      (typed_default_parameter
+        [
+          (identifier) @argname
+        ])
     ]))
-(function_definition
-  parameters: (parameters
-    (default_parameter
-      [
-        (identifier) @argname
-      ])))
-(function_definition
-  parameters: (parameters
-    (typed_parameter
-      [
-        (identifier) @argname
-        (list_splat_pattern
-          (identifier) @argname)
-        (dictionary_splat_pattern
-          (identifier) @argname)
-      ])))
-(function_definition
-  parameters: (parameters
-    (typed_default_parameter
-      [
-        (identifier) @argname
-      ])))
 (lambda
   parameters: (lambda_parameters
     [
@@ -37,4 +31,8 @@
         (identifier) @argname)
       (dictionary_splat_pattern
         (identifier) @argname)
+      (default_parameter
+        [
+          (identifier) @argname
+        ])
     ]))

--- a/queries/python/function_arguments.scm
+++ b/queries/python/function_arguments.scm
@@ -28,7 +28,5 @@
       (dictionary_splat_pattern
         (identifier) @argname)
       (default_parameter
-        [
-          (identifier) @argname
-        ])
+        (identifier) @argname)
     ]))

--- a/queries/python/function_arguments.scm
+++ b/queries/python/function_arguments.scm
@@ -9,6 +9,12 @@
     ]))
 (function_definition
   parameters: (parameters
+    (default_parameter
+      [
+        (identifier) @argname
+      ])))
+(function_definition
+  parameters: (parameters
     (typed_parameter
       [
         (identifier) @argname
@@ -16,6 +22,12 @@
           (identifier) @argname)
         (dictionary_splat_pattern
           (identifier) @argname)
+      ])))
+(function_definition
+  parameters: (parameters
+    (typed_default_parameter
+      [
+        (identifier) @argname
       ])))
 (lambda
   parameters: (lambda_parameters
@@ -26,4 +38,3 @@
       (dictionary_splat_pattern
         (identifier) @argname)
     ]))
-

--- a/testfiles/test.py
+++ b/testfiles/test.py
@@ -44,5 +44,6 @@ def fn_typed_splat_dict(arg10: int, **arg11: dict[int, str]) -> None:
 def fn_default_values(arg12="foo", arg13: int = 1) -> None:
     if arg12 == "foo":
         Class(arg12, arg13)
+        Class(arg1=arg12, arg2=arg13)
     else:
-        Class(arg12, lambda arg14=0: arg14 + arg13)
+        Class(arg12, arg2=lambda arg14=0: arg14 + arg13)

--- a/testfiles/test.py
+++ b/testfiles/test.py
@@ -40,3 +40,9 @@ def fn_splat_dict(arg8, **arg9) -> None:
 def fn_typed_splat_dict(arg10: int, **arg11: dict[int, str]) -> None:
     if arg11 == {}:
         Class(arg10, lambda **kwargs: kwargs == {var: "var"})
+
+def fn_default_values(arg12="foo", arg13: int = 1) -> None:
+    if arg12 == "foo":
+        Class(arg12, arg13)
+    else:
+        Class(arg12, lambda arg14=0: arg14 + arg13)


### PR DESCRIPTION
This is for arguments like

```python
def f(with_default=0, typed_with_default: str = "foo"): ...
```

I still need to add tests. Just wanted to check with you that this looks ok.