### PR TITLE
feat(config): make the highlight group more customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ require('hlargs').setup()
 To change them
 ```lua
 require('hlargs').setup {
-  color = "#ef9062",
+  color = '#ef9062',
+  highlight = {},
   excluded_filetypes = {},
   disable = function(lang, bufnr) -- If changed, `excluded_filetypes` will be ignored
     return vim.tbl_contains(opts.excluded_filetypes, lang)
@@ -82,10 +83,6 @@ require('hlargs').toggle()
 
 ## Dynamically change color
 If you want to change the color dynamically, according to filetype or whatever, you can do that using the highlight group `Hlargs`
-Also, if your colorscheme highlights `TSParameter`, you can link `Hlargs` to `TSParameter`:
-```lua
-vim.cmd [[autocmd ColorScheme * highlight! link Hlargs TSParameter]]
-```
 
 ## Supported languages
 Currently these languages are supported

--- a/doc/hlargs.txt
+++ b/doc/hlargs.txt
@@ -22,7 +22,8 @@ table with the settings you want to override. The defaults are the following:
 
 >
     require('hlargs').setup {
-      color = "#ef9062",
+      color = '#ef9062',
+      highlight = {},
       excluded_filetypes = {},
       disable = function(lang, bufnr) -- If changed, `excluded_filetypes` will be ignored
         return vim.tbl_contains(opts.excluded_filetypes, lang)
@@ -62,11 +63,17 @@ change the settings you want to differ.
 
 For performance related configurations, see |hlargs-performance|
 
-
-color                                                   *hlargs-config-colors*
-    Description: Hex color to be applied to arguments
+color                                                    *hlargs-config-color*
+    Description: Hex color to be applied to arguments. Used if `highlight` is
+    an empty table and ignored if `highlight` is not an empty table (and
+    `highlight` will be used).
     Type: `string`
-    Default: "#ef9062"
+    Default: '#ef9062'
+
+highlight                                            *hlargs-config-highlight*
+    Description: Highlights to be applied to arguments, see |nvim_set_hl|.
+    Type: `table`
+    Default: `{}`
 
 excluded_filetypes                          *hlargs-config-excluded_filetypes*
     Description: Specify filetypes to be excluded. Ignored if `disable` is
@@ -79,11 +86,11 @@ disable                                                *hlargs-config-disable*
     ignored. Return `true` to disable, `false` to enable.
     Type: `function`
     Default:
-    >
+>
         disable = function(lang, bufnr)
             return vim.tbl_contains(opts.excluded_filetypes, lang)
         end
-    <
+<
 
 paint_arg_declarations                  *hlargs-config-paint_arg_declarations*
     Description: Whether argument declarations should be colored or not
@@ -107,7 +114,7 @@ excluded_argnames                            *hlargs-config-excluded_argnames*
     language/keyword by default.
     Type: `table`
     Default:
-    >
+>
     {
         declarations = {},
         usages = {
@@ -115,18 +122,14 @@ excluded_argnames                            *hlargs-config-excluded_argnames*
             lua = { 'self' }
         }
     }
-    <
+<
 
 
 ==============================================================================
 CUSTOMIZATION                                               *hlargs-customize*
 
 If you want to change the color dynamically, according to filetype or whatever,
-you can do that using the highlight group `Hlargs` Also, if your colorscheme
-highlights `TSParameter`, you can link `Hlargs` to `TSParameter`:
-```lua
-vim.cmd [[autocmd ColorScheme * highlight! link Hlargs TSParameter]]
-```
+you can do that using the highlight group `Hlargs`
 
 ==============================================================================
 PERFORMANCE                                               *hlargs-performance*
@@ -193,13 +196,13 @@ debounce                                                     *hlargs-debounce*
     Type: `table`
     Unit: ms
     Default:
-    >
+>
         {
             partial_parse = 3,
             partial_insert_mode = 100,
             total_parse = 700,
             slow_parse = 5000
         }
-    <
+<
 
 vim:tw=78:et:ft=help:norl:

--- a/lua/hlargs/config.lua
+++ b/lua/hlargs/config.lua
@@ -1,7 +1,8 @@
 local M = {}
 
 local defaults = {
-  color = "#ef9062",
+  color = '#ef9062',
+  highlight = {},
   excluded_filetypes = {},
   disable = function(lang, bufnr)
     return vim.tbl_contains(M.opts.excluded_filetypes, lang)
@@ -32,7 +33,12 @@ local defaults = {
 
 function M.setup(opts)
   M.opts = vim.tbl_deep_extend("force", {}, defaults, opts or {})
-  vim.cmd("highlight def Hlargs guifg=" .. M.opts.color)
+  if vim.tbl_isempty(M.opts.highlight) then
+    vim.api.nvim_set_hl(0, 'Hlargs', { fg = M.opts.color, default = true })
+  else
+    M.opts.highlight.default = true
+    vim.api.nvim_set_hl(0, 'Hlargs', M.opts.highlight)
+  end
 end
 
 return M


### PR DESCRIPTION
TODO: Should we respect the original default value (`{ fg = '#ef9062' }`) or use the new one (`{ link = 'TSParameter' }`)?
