### PR TITLE
fix(colorpalette): fix colorpalette neovim 0.8

### DIFF
--- a/lua/hlargs/colorpalette.lua
+++ b/lua/hlargs/colorpalette.lua
@@ -2,21 +2,19 @@ local config = require("hlargs.config")
 
 local M = {}
 
-
 -- https://cp-algorithms.com/string/string-hashing.html
 local P = 103
---math.maxinteger lua >= 5.3
-local MAX_INT = 9223372036854775807LL
+local MAX_INT = 1e9 + 9
 
 local hash_arg = function(arg_name)
-    local hash_value = 0
-    local p_pow = 1
-    for i=1,#arg_name do
-        local ascii = arg_name:byte(i)
-        hash_value = (hash_value + ascii * p_pow) % MAX_INT
-        p_pow = (p_pow * P) % MAX_INT
-    end
-    return hash_value
+  local hash_value = 0
+  local p_pow = 1
+  for i = 1, #arg_name do
+    local ascii = arg_name:byte(i)
+    hash_value = (hash_value + ascii * p_pow) % MAX_INT
+    p_pow = (p_pow * P) % MAX_INT
+  end
+  return hash_value
 end
 
 M.get_hlgroup = function(arg_name)


### PR DESCRIPTION
Hello, I found that `hash_arg` on neovim nighty work unexpected `E5248: Invalid character in group name`, after change from maxint LL to 1e9 + 9 became stable.