### PR TITLE
fix: java incorrect arg highlight issue

### DIFF
--- a/lua/hlargs/util.lua
+++ b/lua/hlargs/util.lua
@@ -17,7 +17,8 @@ local ignored_field_names = {
     attrpath = { 'attr' }
   },
   java = {
-    _ = { 'field' }
+    method_invocation = { 'name' },
+    field_access = { 'field' }
   },
   vim = {
     scoped_identifier = { '_' }

--- a/queries/java/function_arguments.scm
+++ b/queries/java/function_arguments.scm
@@ -6,6 +6,8 @@
   parameters: (formal_parameters
     (formal_parameter
       (identifier) @argname)))
+(lambda_expression
+  parameters: (identifier) @argname)
 (catch_clause
   (catch_formal_parameter
     name: (identifier) @catch))

--- a/testfiles/test.java
+++ b/testfiles/test.java
@@ -3,8 +3,17 @@ import java.util.*;
 public class Class {
     private final static Long arg2 = 25L;
 
-    private static int fn(int arg1, int arg2){
-        return arg1 * Class.arg2.intValue() +5;
+    private static int fn(Arg arg1, int arg2) {
+        return arg1.arg1() * Class.arg2.intValue() + arg2;
+    }
+
+    private static Optional<Builder> build(int field, Optional<Integer> anotherFieldOptional) {
+        return anotherFieldOptional.map(
+                anotherField ->
+                    Builder.builder()
+                        .field(field)
+                        .anotherField(anotherField)
+                        .build())
     }
 
     public static void main(String []args) {


### PR DESCRIPTION
Fix two issues for Java:
1. `ignored_field_names` for Java is incomplete.
2. Missing query for another lambda expression type

Before this fix (current state):
![before](https://github.com/m-demare/hlargs.nvim/assets/433126/b5ad7d6b-355b-45a2-a81a-ee6a6ab34571)

After with fix:
![after](https://github.com/m-demare/hlargs.nvim/assets/433126/b631b585-1f01-4114-83f4-b6af2e2cd60c)
