### PR TITLE
Added text decoration configuration item

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ A list of text decorations can be found [here](https://neovim.io/doc/user/api.ht
 
 Text decorations example:
 ```lua
-{
-		highlight = {
-			fg ="#ef9062",
-			italic = true,
-		}
+require('hlargs').setup {
+	highlight = {
+		fg ="#ef9062",
+		italic = true,
+	}
 }
 ```
 
@@ -126,28 +126,28 @@ Text decorations can be used in combination with the color palette, applying to 
 
 Text decorations with color palette example:
 ```lua
-{
-	use_colorpalette = true,
-	sequential_colorpalette = true,
-	colorpalette = {
-	  { fg = "#ef9062" },
-	  { fg = "#3AC6BE" },
-	  { fg = "#35D27F" },
-	  { fg = "#EB75D6" },
-	  { fg = "#E5D180" },
-	  { fg = "#8997F5" },
-	  { fg = "#D49DA5" },
-	  { fg = "#7FEC35" },
-	  { fg = "#F6B223" },
-	  { fg = "#F67C1B" },
-	  { fg = "#DE9A4E" },
-	  { fg = "#BBEA87" },
-	  { fg = "#EEF06D" },
-	  { fg = "#8FB272" },
-	},
-	highlight = {
-	  italic = true,
-	}
+require('hlargs').setup {
+    use_colorpalette = true,
+    sequential_colorpalette = true,
+    colorpalette = {
+        { fg = "#ef9062" },
+        { fg = "#3AC6BE" },
+        { fg = "#35D27F" },
+        { fg = "#EB75D6" },
+        { fg = "#E5D180" },
+        { fg = "#8997F5" },
+        { fg = "#D49DA5" },
+        { fg = "#7FEC35" },
+        { fg = "#F6B223" },
+        { fg = "#F67C1B" },
+        { fg = "#DE9A4E" },
+        { fg = "#BBEA87" },
+        { fg = "#EEF06D" },
+        { fg = "#8FB272" },
+    },
+    highlight = {
+      italic = true,
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,51 @@ require('hlargs').toggle()
 ## Dynamically change color
 If you want to change the color dynamically, according to filetype or whatever, you can do that using the highlight group `Hlargs`
 
+## Add text decorations
+
+Text decorations can be applied using the `highlight` option
+
+A list of text decorations can be found [here](https://neovim.io/doc/user/api.html#nvim_set_hl()).
+
+Text decorations example:
+```lua
+{
+		highlight = {
+			fg ="#ef9062",
+			italic = true,
+		}
+}
+```
+
+Text decorations can be used in combination with the color palette, applying to every color in the color palette.
+
+Text decorations with color palette example:
+```lua
+{
+	use_colorpalette = true,
+	sequential_colorpalette = true,
+	colorpalette = {
+	  { fg = "#ef9062" },
+	  { fg = "#3AC6BE" },
+	  { fg = "#35D27F" },
+	  { fg = "#EB75D6" },
+	  { fg = "#E5D180" },
+	  { fg = "#8997F5" },
+	  { fg = "#D49DA5" },
+	  { fg = "#7FEC35" },
+	  { fg = "#F6B223" },
+	  { fg = "#F67C1B" },
+	  { fg = "#DE9A4E" },
+	  { fg = "#BBEA87" },
+	  { fg = "#EEF06D" },
+	  { fg = "#8FB272" },
+	},
+	highlight = {
+	  italic = true,
+	}
+}
+```
+
 ## Supported languages
 Currently these languages are supported
 - c

--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ A list of text decorations can be found [here](https://neovim.io/doc/user/api.ht
 Text decorations example:
 ```lua
 require('hlargs').setup {
-	highlight = {
-		fg ="#ef9062",
-		italic = true,
-	}
+  highlight = {
+	fg ="#ef9062",
+	italic = true
+  }
 }
 ```
 
@@ -127,27 +127,27 @@ Text decorations can be used in combination with the color palette, applying to 
 Text decorations with color palette example:
 ```lua
 require('hlargs').setup {
-    use_colorpalette = true,
-    sequential_colorpalette = true,
-    colorpalette = {
-        { fg = "#ef9062" },
-        { fg = "#3AC6BE" },
-        { fg = "#35D27F" },
-        { fg = "#EB75D6" },
-        { fg = "#E5D180" },
-        { fg = "#8997F5" },
-        { fg = "#D49DA5" },
-        { fg = "#7FEC35" },
-        { fg = "#F6B223" },
-        { fg = "#F67C1B" },
-        { fg = "#DE9A4E" },
-        { fg = "#BBEA87" },
-        { fg = "#EEF06D" },
-        { fg = "#8FB272" },
-    },
-    highlight = {
-      italic = true,
-    }
+  use_colorpalette = true,
+  sequential_colorpalette = true,
+  colorpalette = {
+      { fg = "#ef9062" },
+      { fg = "#3AC6BE" },
+      { fg = "#35D27F" },
+      { fg = "#EB75D6" },
+      { fg = "#E5D180" },
+      { fg = "#8997F5" },
+      { fg = "#D49DA5" },
+      { fg = "#7FEC35" },
+      { fg = "#F6B223" },
+      { fg = "#F67C1B" },
+      { fg = "#DE9A4E" },
+      { fg = "#BBEA87" },
+      { fg = "#EEF06D" },
+      { fg = "#8FB272" }
+  },
+  highlight = {
+    italic = true
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ A list of text decorations can be found [here](https://neovim.io/doc/user/api.ht
 Text decorations example:
 ```lua
 require('hlargs').setup {
-	highlight = {
-		fg ="#ef9062",
-		italic = true,
-	}
+  highlight = {
+   fg ="#ef9062",
+   italic = true
+  }
 }
 ```
 
@@ -127,27 +127,27 @@ Text decorations can be used in combination with the color palette, applying to 
 Text decorations with color palette example:
 ```lua
 require('hlargs').setup {
-    use_colorpalette = true,
-    sequential_colorpalette = true,
-    colorpalette = {
-        { fg = "#ef9062" },
-        { fg = "#3AC6BE" },
-        { fg = "#35D27F" },
-        { fg = "#EB75D6" },
-        { fg = "#E5D180" },
-        { fg = "#8997F5" },
-        { fg = "#D49DA5" },
-        { fg = "#7FEC35" },
-        { fg = "#F6B223" },
-        { fg = "#F67C1B" },
-        { fg = "#DE9A4E" },
-        { fg = "#BBEA87" },
-        { fg = "#EEF06D" },
-        { fg = "#8FB272" },
-    },
-    highlight = {
-      italic = true,
-    }
+  use_colorpalette = true,
+  sequential_colorpalette = true,
+  colorpalette = {
+    { fg = "#ef9062" },
+    { fg = "#3AC6BE" },
+    { fg = "#35D27F" },
+    { fg = "#EB75D6" },
+    { fg = "#E5D180" },
+    { fg = "#8997F5" },
+    { fg = "#D49DA5" },
+    { fg = "#7FEC35" },
+    { fg = "#F6B223" },
+    { fg = "#F67C1B" },
+    { fg = "#DE9A4E" },
+    { fg = "#BBEA87" },
+    { fg = "#EEF06D" },
+    { fg = "#8FB272" }
+  },
+  highlight = {
+    italic = true
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ A list of text decorations can be found [here](https://neovim.io/doc/user/api.ht
 Text decorations example:
 ```lua
 require('hlargs').setup {
-  highlight = {
-	fg ="#ef9062",
-	italic = true
-  }
+	highlight = {
+		fg ="#ef9062",
+		italic = true,
+	}
 }
 ```
 
@@ -127,27 +127,27 @@ Text decorations can be used in combination with the color palette, applying to 
 Text decorations with color palette example:
 ```lua
 require('hlargs').setup {
-  use_colorpalette = true,
-  sequential_colorpalette = true,
-  colorpalette = {
-      { fg = "#ef9062" },
-      { fg = "#3AC6BE" },
-      { fg = "#35D27F" },
-      { fg = "#EB75D6" },
-      { fg = "#E5D180" },
-      { fg = "#8997F5" },
-      { fg = "#D49DA5" },
-      { fg = "#7FEC35" },
-      { fg = "#F6B223" },
-      { fg = "#F67C1B" },
-      { fg = "#DE9A4E" },
-      { fg = "#BBEA87" },
-      { fg = "#EEF06D" },
-      { fg = "#8FB272" }
-  },
-  highlight = {
-    italic = true
-  }
+    use_colorpalette = true,
+    sequential_colorpalette = true,
+    colorpalette = {
+        { fg = "#ef9062" },
+        { fg = "#3AC6BE" },
+        { fg = "#35D27F" },
+        { fg = "#EB75D6" },
+        { fg = "#E5D180" },
+        { fg = "#8997F5" },
+        { fg = "#D49DA5" },
+        { fg = "#7FEC35" },
+        { fg = "#F6B223" },
+        { fg = "#F67C1B" },
+        { fg = "#DE9A4E" },
+        { fg = "#BBEA87" },
+        { fg = "#EEF06D" },
+        { fg = "#8FB272" },
+    },
+    highlight = {
+      italic = true,
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -106,51 +106,6 @@ require('hlargs').toggle()
 ## Dynamically change color
 If you want to change the color dynamically, according to filetype or whatever, you can do that using the highlight group `Hlargs`
 
-## Add text decorations
-
-Text decorations can be applied using the `highlight` option
-
-A list of text decorations can be found [here](https://neovim.io/doc/user/api.html#nvim_set_hl()).
-
-Text decorations example:
-```lua
-require('hlargs').setup {
-  highlight = {
-   fg ="#ef9062",
-   italic = true
-  }
-}
-```
-
-Text decorations can be used in combination with the color palette, applying to every color in the color palette.
-
-Text decorations with color palette example:
-```lua
-require('hlargs').setup {
-  use_colorpalette = true,
-  sequential_colorpalette = true,
-  colorpalette = {
-    { fg = "#ef9062" },
-    { fg = "#3AC6BE" },
-    { fg = "#35D27F" },
-    { fg = "#EB75D6" },
-    { fg = "#E5D180" },
-    { fg = "#8997F5" },
-    { fg = "#D49DA5" },
-    { fg = "#7FEC35" },
-    { fg = "#F6B223" },
-    { fg = "#F67C1B" },
-    { fg = "#DE9A4E" },
-    { fg = "#BBEA87" },
-    { fg = "#EEF06D" },
-    { fg = "#8FB272" }
-  },
-  highlight = {
-    italic = true
-  }
-}
-```
-
 ## Supported languages
 Currently these languages are supported
 - c

--- a/lua/hlargs/config.lua
+++ b/lua/hlargs/config.lua
@@ -43,6 +43,16 @@ local defaults = {
       lua = { "self" },
     },
   },
+  textDecorations = {
+    italic = false,
+    bold = false,
+    standout = false,
+    underline = false,
+    undercurl = false,
+    underdouble = false,
+    underdashed = false,
+    strikethrough = false,
+  },
   performance = {
     parse_delay = 1,
     slow_parse_delay = 50,
@@ -64,11 +74,19 @@ function M.setup(opts)
     if M.opts.use_colorpalette then
       for i, color in pairs(M.opts.colorpalette) do
         color.default = true
-        vim.api.nvim_set_hl(0, "Hlarg" .. i, color)
+        vim.api.nvim_set_hl(0, "Hlarg" .. i, vim.tbl_deep_extend("force", color, M.opts.textDecorations))
       end
     else
       if vim.tbl_isempty(M.opts.highlight) then
-        vim.api.nvim_set_hl(0, "Hlargs", { fg = M.opts.color, default = true })
+        local color = {
+          fg = M.opts.color,
+          default = true,
+        }
+        vim.api.nvim_set_hl(
+          0,
+          "Hlargs",
+          vim.tbl_deep_extend("force", color, M.opts.textDecorations)
+        )
       else
         M.opts.highlight.default = true
         vim.api.nvim_set_hl(0, "Hlargs", M.opts.highlight)

--- a/lua/hlargs/config.lua
+++ b/lua/hlargs/config.lua
@@ -43,16 +43,6 @@ local defaults = {
       lua = { "self" },
     },
   },
-  textDecorations = {
-    italic = false,
-    bold = false,
-    standout = false,
-    underline = false,
-    undercurl = false,
-    underdouble = false,
-    underdashed = false,
-    strikethrough = false,
-  },
   performance = {
     parse_delay = 1,
     slow_parse_delay = 50,
@@ -74,19 +64,14 @@ function M.setup(opts)
     if M.opts.use_colorpalette then
       for i, color in pairs(M.opts.colorpalette) do
         color.default = true
-        vim.api.nvim_set_hl(0, "Hlarg" .. i, vim.tbl_deep_extend("force", color, M.opts.textDecorations))
+        if(not vim.tbl_isempty(M.opts.highlight)) then
+          color = vim.tbl_deep_extend("force",color,M.opts.highlight)
+        end
+        vim.api.nvim_set_hl(0, "Hlarg" .. i, color)
       end
     else
       if vim.tbl_isempty(M.opts.highlight) then
-        local color = {
-          fg = M.opts.color,
-          default = true,
-        }
-        vim.api.nvim_set_hl(
-          0,
-          "Hlargs",
-          vim.tbl_deep_extend("force", color, M.opts.textDecorations)
-        )
+        vim.api.nvim_set_hl(0, "Hlargs", { fg = M.opts.color, default = true })
       else
         M.opts.highlight.default = true
         vim.api.nvim_set_hl(0, "Hlargs", M.opts.highlight)


### PR DESCRIPTION
### Added ability to use text decorations (italics, bold, underline, etc) via a configuration item called `textDecorations`.

- All decorations are disabled by default.
- A list of possible text decorations can be found [here](https://neovim.io/doc/user/api.html#nvim_set_hl()).
- When using the color palette, text decorations will apply to every color.


_This is my first attempt at Lua so let me know if there is a better way to do this._


 