### PR TITLE
fix: fixed params arguments not matching in function_arguments

### DIFF
--- a/queries/c_sharp/function_arguments.scm
+++ b/queries/c_sharp/function_arguments.scm
@@ -1,3 +1,4 @@
-(parameter
+(parameter 
   name: (identifier) @argname)
-
+(parameter_list  
+  name: (identifier) @argname)

--- a/testfiles/test.cs
+++ b/testfiles/test.cs
@@ -19,12 +19,14 @@ class Program {
 }
 
 class MyClass {
-  public MyClass(int arg0, float arg1) {
+  public MyClass(int arg0, float arg1, params string[] args) {
     this.arg0_ = arg0;
     this.arg1 = arg1;
+    this.args = args;
   }
   int arg0_;
   private float arg1;
+  string[] args;
 
   int fn(char arg2, int arg3 = 0) {
     return arg3 + arg2;


### PR DESCRIPTION
Fixed that previously argument passed with `params` keyword wouldn't match

Updated test file before:
![image](https://github.com/user-attachments/assets/5d110db5-6383-4ef7-a8b7-8ce308ee0c2a)

And after:
![image](https://github.com/user-attachments/assets/3db47971-1568-4a1e-8428-5ea39b8a68bc)
