### PR TITLE
refactor!: add LuaLS annotations, fix 'vim.loop' usage, improve code

### DIFF
--- a/lua/hlargs.lua
+++ b/lua/hlargs.lua
@@ -1,10 +1,12 @@
 local events = require "hlargs.events"
 local config = require "hlargs.config"
 
+---@class HlArgs
 local M = {}
 
-M.setup = function(opts)
-  if vim.fn.has "nvim-0.7" == 0 then
+---@param opts? HlArgsOpts
+function M.setup(opts)
+  if vim.fn.has "nvim-0.7" ~= 1 then
     vim.api.nvim_err_writeln [[
             Neovim 0.7 is required for this version of hlargs
             If you're using 0.6, check the README on the branch 0.6-compat

--- a/lua/hlargs/async.lua
+++ b/lua/hlargs/async.lua
@@ -1,14 +1,22 @@
-local function attach(bufnr, callabcks)
+local uv = vim.uv or vim.loop
+
+---@class HlArgs.Async
+local M = {}
+
+---@param bufnr integer
+---@param callbacks vim.api.keyset.buf_attach
+---@return function
+function M.attach(bufnr, callbacks)
   local detached = false
 
   vim.api.nvim_buf_attach(bufnr, false, {
     on_lines = function(...)
       if detached then return true end
-      callabcks.on_lines(...)
+      callbacks.on_lines(...)
     end,
     on_reload = function(...)
-      if detached then return true end
-      callabcks.on_reload(...)
+      if detached then return end
+      callbacks.on_reload(...)
     end,
   })
 
@@ -17,7 +25,10 @@ local function attach(bufnr, callabcks)
   end
 end
 
-local function defer(fn, time)
+---@param fn function
+---@param time integer
+---@return function
+function M.defer(fn, time)
   local cancelled = false
   local t = vim.defer_fn(function()
     if cancelled then return end
@@ -28,11 +39,8 @@ local function defer(fn, time)
     cancelled = true  -- It seems like there's some sort of race condition with these
                       -- timers, they occasionally get executed after being cancelled.
                       -- This flag prevents that behaviour.
-    vim.loop.timer_stop(t)
+    uv.timer_stop(t)
   end
 end
 
-return {
-  attach = attach,
-  defer = defer,
-}
+return M

--- a/lua/hlargs/bufdata.lua
+++ b/lua/hlargs/bufdata.lua
@@ -2,34 +2,63 @@ local M = {}
 local util = require "hlargs.util"
 local paint = require "hlargs.paint"
 
-local data = {}
+local data = {} ---@type table<integer, HlArgs.BufData.Data>
 local main_ns = vim.api.nvim_create_namespace "hlargs_main"
 
-M.TaskTypes = {
-  PARTIAL = 1,
-  TOTAL = 2,
-  SLOW = 3,
-}
+---@class HlArgs.BufData.Debouncers
+---@field range_queue? function
+---@field total_parse? function
+---@field slow_parse? function
 
+---@class HlArgs.BufData.Task
+---@field change_idx integer
+---@field mark? integer
+---@field ns integer
+---@field stop boolean
+---@field stopped_tasks? HlArgs.BufData.Task[]
+---@field type TaskTypes
+
+---@class HlArgs.BufData.Data
+---@field change_idx integer
+---@field debouncers HlArgs.BufData.Debouncers
+---@field detach? function
+---@field filetype? string
+---@field ignore? boolean
+---@field initialized boolean
+---@field marks_ns integer
+---@field ranges_to_parse? integer[]
+---@field tasks HlArgs.BufData.Task[]
+---@field ts_cb_attached boolean
+
+---@enum TaskTypes
+M.TaskTypes = { PARTIAL = 1, TOTAL = 2, SLOW = 3 }
+
+---@param bufnr integer
+---@return HlArgs.BufData.Data data
 function M.get(bufnr)
-  data[bufnr] = data[bufnr]
-    or {
-      change_idx = 0,
-      tasks = {},
-      debouncers = {},
-      ranges_to_parse = {},
-      marks_ns = vim.api.nvim_create_namespace "",
-      initialized = false,
-      ts_cb_attached = false,
-    }
+  local default = { ---@type HlArgs.BufData.Data
+    change_idx = 0,
+    tasks = {},
+    debouncers = {},
+    ranges_to_parse = {},
+    marks_ns = vim.api.nvim_create_namespace "",
+    initialized = false,
+    ts_cb_attached = false,
+  }
+  data[bufnr] = data[bufnr] or default
   return data[bufnr]
 end
 
+---@return table<integer, HlArgs.BufData.Data> data
 function M.get_all()
   return data
 end
 
-function M.new_task(bufnr, type, mark)
+---@param bufnr integer
+---@param task_type TaskTypes
+---@param mark integer
+---@return HlArgs.BufData.Task task
+function M.new_task(bufnr, task_type, mark)
   local buf_data = M.get(bufnr)
   if buf_data.ignore then
     error(
@@ -41,19 +70,21 @@ function M.new_task(bufnr, type, mark)
   end
   buf_data.change_idx = buf_data.change_idx + 1
 
-  local task = {
-    mark = mark,
+  local task = { ---@type HlArgs.BufData.Task
     change_idx = buf_data.change_idx,
+    mark = mark,
     ns = vim.api.nvim_create_namespace "",
     stop = false,
-    type = type,
     stopped_tasks = {},
+    type = task_type,
   }
 
   table.insert(buf_data.tasks, task)
   return task
 end
 
+---@param bufnr integer
+---@return boolean running
 function M.total_parse_is_running(bufnr)
   local buf_data = M.get(bufnr)
   for _, t in ipairs(buf_data.tasks) do
@@ -62,6 +93,9 @@ function M.total_parse_is_running(bufnr)
   return false
 end
 
+---@param bufnr integer
+---@param buf_data HlArgs.BufData.Data
+---@param task HlArgs.BufData.Task
 local function clean_stopped_tasks(bufnr, buf_data, task)
   if not task.stopped_tasks then return end
   for _, t in ipairs(task.stopped_tasks) do
@@ -71,9 +105,11 @@ local function clean_stopped_tasks(bufnr, buf_data, task)
   end
 end
 
+---@param bufnr integer
+---@param task HlArgs.BufData.Task
 function M.end_task(bufnr, task)
   local buf_data = M.get(bufnr)
-  local limits = nil
+  local limits = nil ---@type nil|{ [1]: integer, [2]: integer }
   if task.mark and vim.api.nvim_buf_is_loaded(bufnr) then
     local from, to = util.get_marks_limits(bufnr, buf_data.marks_ns, task.mark)
     limits = { from, to + 1 }
@@ -96,13 +132,15 @@ function M.end_task(bufnr, task)
   for i = #buf_data.tasks, 1, -1 do
     if buf_data.tasks[i] == task then table.remove(buf_data.tasks, i) end
   end
-  if #buf_data.tasks == 0 then
+  if vim.tbl_isempty(buf_data.tasks) then
     -- Reset change_idx so that it doesn't grow too much
     -- (Especially for people who never close nvim)
     buf_data.change_idx = 0
   end
 end
 
+---@param bufnr integer
+---@param task HlArgs.BufData.Task
 function M.stop_older_contained(bufnr, task)
   if not vim.api.nvim_buf_is_loaded(bufnr) then return end
   local buf_data = M.get(bufnr)
@@ -123,6 +161,7 @@ function M.stop_older_contained(bufnr, task)
   end
 end
 
+---@param buf_data HlArgs.BufData.Data
 local function clean_debouncers(buf_data)
   if buf_data.debouncers.range_queue then buf_data.debouncers.range_queue() end
   if buf_data.debouncers.total_parse then buf_data.debouncers.total_parse() end
@@ -130,6 +169,7 @@ local function clean_debouncers(buf_data)
 end
 
 -- Gets called on disable / BufDelete
+---@param bufnr integer
 function M.delete_data(bufnr)
   if data[bufnr] == nil then return end
   for _, t in ipairs(data[bufnr].tasks) do
@@ -146,7 +186,11 @@ function M.delete_data(bufnr)
 end
 
 function M.debug()
-  vim.pretty_print(data)
+  if vim.fn.has "nvim-0.9" ~= 1 then
+    vim.pretty_print(data)
+    return
+  end
+  vim.print(data)
 end
 
 return M

--- a/lua/hlargs/colorpalette.lua
+++ b/lua/hlargs/colorpalette.lua
@@ -2,16 +2,19 @@ local config = require "hlargs.config"
 local parse = require "hlargs.parse"
 local util = require "hlargs.util"
 
+---@class HlArgs.ColorPalette
 local M = {}
 
 -- https://cp-algorithms.com/string/string-hashing.html
 local P = 103
 local MAX_INT = 1e9 + 9
 
-local hash_arg = function(arg_name)
+---@param arg_name string
+---@return integer hash_value
+local function hash_arg(arg_name)
   local hash_value = 0
   local p_pow = 1
-  for i = 1, #arg_name do
+  for i = 1, arg_name:len() do
     local ascii = arg_name:byte(i)
     hash_value = (hash_value + ascii * p_pow) % MAX_INT
     p_pow = (p_pow * P) % MAX_INT
@@ -19,22 +22,33 @@ local hash_arg = function(arg_name)
   return hash_value
 end
 
-M.get_hlgroup_hashed = function(arg_name)
-  local config = config.opts
-  local size = #config.colorpalette
+---@param arg_name string
+---@return string hashed_hlgroup
+function M.get_hlgroup_hashed(arg_name)
+  local opts = config.opts
+  local size = #opts.colorpalette
   local idx = hash_arg(arg_name)
   local current_color = idx % size
 
   return "Hlarg" .. tonumber(current_color)
 end
 
-M.get_hlgroup_sequential = function(bufnr, start_row, start_col, end_row, end_col, arg_name)
+---@param bufnr integer
+---@param start_row integer
+---@param start_col integer
+---@param end_row integer
+---@param end_col integer
+---@param arg_name string
+---@return string sequential_hlgroup
+function M.get_hlgroup_sequential(bufnr, start_row, start_col, end_row, end_col, arg_name)
   local lang = util.get_lang(bufnr)
   local parser = vim.treesitter.get_parser(bufnr, lang)
-  local root = parser:parse()[1]:root()
-  local node = root:named_descendant_for_range(start_row, start_col, end_row, end_col)
+  if not parser then return "" end
+
+  local node =
+    parser:parse()[1]:root():named_descendant_for_range(start_row, start_col, end_row, end_col)
   local functionNode = util.get_first_function_parent(lang, node)
-  local arg_nodes, arg_names_set = parse.get_args(bufnr, functionNode)
+  local arg_nodes, _ = parse.get_args(bufnr, "", functionNode)
   local current_color = 1
   local node_index = 1
   for _, arg_node in ipairs(arg_nodes) do

--- a/lua/hlargs/config.lua
+++ b/lua/hlargs/config.lua
@@ -1,5 +1,47 @@
+---@class HlArgsOpts.ExcludedArgnames
+---@field declarations? table<string, string[]>
+---@field usages? table<string, string[]>
+
+---@class HlArgsOpts.Performance.Debounce
+---@field partial_parse? integer
+---@field partial_insert_mode? integer
+---@field total_parse? integer
+---@field slow_parse? integer
+
+---@class HlArgsOpts.Performance
+---@field parse_delay? integer
+---@field slow_parse_delay? integer
+---@field max_iterations? integer
+---@field max_concurrent_partial_parses? integer
+---@field debounce? HlArgsOpts.Performance.Debounce
+
+---@class HlArgsOpts.PaintCatchBlocks
+---@field declarations? boolean
+---@field usages? boolean
+
+---@class HlArgsOpts.Extras
+---@field named_parameters? false|vim.api.keyset.highlight
+---@field unused_args? false|vim.api.keyset.highlight
+
+---@class HlArgs.Config
+---@field opts HlArgsOpts
 local M = {}
 
+---@class HlArgsOpts
+---@field enabled? boolean
+---@field color? string
+---@field use_colorpalette? boolean
+---@field sequential_colorpalette? boolean
+---@field colorpalette? vim.api.keyset.highlight[]
+---@field highlight? vim.api.keyset.highlight
+---@field excluded_filetypes? string[]
+---@field disable? fun(lang: string, bufnr: integer): boolean
+---@field paint_arg_declarations? boolean
+---@field paint_arg_usages? boolean
+---@field extras? HlArgsOpts.Extras
+---@field paint_catch_blocks? HlArgsOpts.PaintCatchBlocks
+---@field hl_priority? integer
+---@field excluded_argnames? HlArgsOpts.ExcludedArgnames
 local defaults = {
   enabled = true,
   color = "#ef9062",
@@ -23,8 +65,8 @@ local defaults = {
   },
   highlight = {},
   excluded_filetypes = {},
-  disable = function(lang, bufnr)
-    return vim.tbl_contains(M.opts.excluded_filetypes, lang)
+  disable = function(lang)
+    return vim.list_contains(M.opts.excluded_filetypes, lang)
   end,
   paint_arg_declarations = true,
   paint_arg_usages = true,
@@ -58,41 +100,44 @@ local defaults = {
   },
 }
 
+function M.create_hl_groups()
+  if M.opts.use_colorpalette then
+    for i, color in pairs(M.opts.colorpalette) do
+      color.default = true
+      if not vim.tbl_isempty(M.opts.highlight) then
+        color = vim.tbl_deep_extend("force", color, M.opts.highlight)
+      end
+      vim.api.nvim_set_hl(0, "Hlarg" .. i, color)
+    end
+  else
+    if vim.tbl_isempty(M.opts.highlight) then
+      vim.api.nvim_set_hl(0, "Hlargs", { fg = M.opts.color, default = true })
+    else
+      M.opts.highlight.default = true
+      vim.api.nvim_set_hl(0, "Hlargs", M.opts.highlight)
+    end
+  end
+  if M.opts.extras.unused_args then
+    vim.api.nvim_set_hl(0, "HlargsUnused", M.opts.extras.unused_args)
+  end
+
+  if M.opts.extras.named_parameters then
+    if M.opts.extras.named_parameters == true then
+      M.opts.extras.named_parameters = { link = "Hlargs" }
+    end
+    vim.api.nvim_set_hl(0, "@HlargsNamedParams", M.opts.extras.named_parameters)
+  end
+end
+
+---@param opts? HlArgsOpts
 function M.setup(opts)
   M.opts = vim.tbl_deep_extend("force", {}, defaults, opts or {})
 
-  local function create_hl_groups()
-    if M.opts.use_colorpalette then
-      for i, color in pairs(M.opts.colorpalette) do
-        color.default = true
-        if not vim.tbl_isempty(M.opts.highlight) then
-          color = vim.tbl_deep_extend("force", color, M.opts.highlight)
-        end
-        vim.api.nvim_set_hl(0, "Hlarg" .. i, color)
-      end
-    else
-      if vim.tbl_isempty(M.opts.highlight) then
-        vim.api.nvim_set_hl(0, "Hlargs", { fg = M.opts.color, default = true })
-      else
-        M.opts.highlight.default = true
-        vim.api.nvim_set_hl(0, "Hlargs", M.opts.highlight)
-      end
-    end
-    if M.opts.extras.unused_args then
-      vim.api.nvim_set_hl(0, "HlargsUnused", M.opts.extras.unused_args)
-    end
-
-    if M.opts.extras.named_parameters then
-      if M.opts.extras.named_parameters == true then M.opts.extras.named_parameters = { link = "Hlargs" } end
-      vim.api.nvim_set_hl(0, "@HlargsNamedParams", M.opts.extras.named_parameters)
-    end
-  end
-
-  create_hl_groups()
+  M.create_hl_groups()
 
   local augroup = vim.api.nvim_create_augroup("hlargs-create-hlgroups", { clear = true })
   vim.api.nvim_create_autocmd("ColorScheme", {
-    callback = create_hl_groups,
+    callback = M.create_hl_groups,
     group = augroup,
   })
 end

--- a/lua/hlargs/events.lua
+++ b/lua/hlargs/events.lua
@@ -1,4 +1,3 @@
-local M = {}
 local parser = require "hlargs.parse"
 local config = require "hlargs.config"
 local util = require "hlargs.util"
@@ -10,6 +9,10 @@ local defer = async.defer
 
 local enabled = false
 
+---@param bufnr integer
+---@param ns integer
+---@param node_group? TSNode[]
+---@param hl_group? string
 local function paint_nodes(bufnr, ns, node_group, hl_group)
   if not node_group then return end
   for _, node in ipairs(node_group) do
@@ -17,6 +20,9 @@ local function paint_nodes(bufnr, ns, node_group, hl_group)
   end
 end
 
+---@param bufnr integer
+---@param task HlArgs.BufData.Task
+---@param co thread
 local function find_and_paint_iteration(bufnr, task, co)
   local delay = config.opts.performance.parse_delay
   if task.type == bufdata.TaskTypes.SLOW then delay = config.opts.performance.slow_parse_delay end
@@ -50,11 +56,19 @@ local function find_and_paint_iteration(bufnr, task, co)
   end, delay)
 end
 
+---@param bufnr integer
+---@return boolean excluded
 local function is_excluded(bufnr)
   local lang = util.get_lang(bufnr)
   return config.opts.disable(lang, bufnr)
 end
 
+---@class HlArgs.Events
+local M = {}
+
+---@param bufnr? integer
+---@param task_type TaskTypes
+---@param mark? integer
 function M.find_and_paint_nodes(bufnr, task_type, mark)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
   if not enabled then return end
@@ -66,6 +80,8 @@ function M.find_and_paint_nodes(bufnr, task_type, mark)
   find_and_paint_iteration(bufnr, task, co)
 end
 
+---@param bufnr integer
+---@param buf_data HlArgs.BufData.Data
 local function schedule_partial_repaints(bufnr, buf_data)
   if not vim.api.nvim_buf_is_valid(bufnr) then return end
   buf_data.ranges_to_parse = util.merge_ranges(bufnr, buf_data.marks_ns, buf_data.ranges_to_parse)
@@ -90,6 +106,9 @@ local function schedule_partial_repaints(bufnr, buf_data)
   M.schedule_slow_repaint(bufnr)
 end
 
+---@param bufnr integer
+---@param from integer
+---@param to integer
 function M.add_range_to_queue(bufnr, from, to)
   if not enabled then return end
   if not vim.api.nvim_buf_is_valid(bufnr) then return end
@@ -126,6 +145,8 @@ function M.add_range_to_queue(bufnr, from, to)
   end, debounce_time)
 end
 
+---@param bufnr integer
+---@param ignore_debounce? boolean
 function M.schedule_total_repaint(bufnr, ignore_debounce)
   if not enabled then return end
   if bufdata.total_parse_is_running(bufnr) then
@@ -142,6 +163,7 @@ function M.schedule_total_repaint(bufnr, ignore_debounce)
   end, debounce_time)
 end
 
+---@param bufnr integer
 function M.schedule_slow_repaint(bufnr)
   if not enabled then return end
 
@@ -152,26 +174,26 @@ function M.schedule_slow_repaint(bufnr)
   end, config.opts.performance.debounce.slow_parse)
 end
 
+---@param data vim.api.keyset.create_autocmd.callback_args|{ buf: integer }
 function M.buf_enter(data)
-  local bufnr = data.buf
-  if is_excluded(bufnr) then return end
-  local buf_data = bufdata.get(bufnr)
+  if is_excluded(data.buf) then return end
+  local buf_data = bufdata.get(data.buf)
   if not buf_data.initialized then
     buf_data.initialized = true
-    local lang = util.get_lang(bufnr)
+    local lang = util.get_lang(data.buf)
     buf_data.ignore = not util.is_supported(lang)
     if buf_data.ignore then return end
-    buf_data.filetype = vim.fn.getbufvar(bufnr, "&filetype")
+    buf_data.filetype = vim.api.nvim_get_option_value("filetype", { buf = data.buf })
 
-    M.schedule_total_repaint(bufnr, true)
+    M.schedule_total_repaint(data.buf, true)
 
-    buf_data.detach = attach(bufnr, {
-      on_lines = function(ev, bufnr, _, from, old_to, to)
+    buf_data.detach = attach(data.buf, {
+      on_lines = function(_, bufnr, _, from, _, to)
         vim.schedule(function()
           M.add_range_to_queue(bufnr, from, to)
         end)
       end,
-      on_reload = function(ev, bufnr)
+      on_reload = function(_, bufnr)
         vim.schedule(function()
           M.schedule_total_repaint(bufnr)
         end)
@@ -180,6 +202,7 @@ function M.buf_enter(data)
   end
 end
 
+---@param data vim.api.keyset.create_autocmd.callback_args|{ buf: integer }
 function M.filetype(data)
   local bufnr = data.buf
   local ft = data.match
@@ -190,11 +213,13 @@ function M.filetype(data)
   end
 end
 
+---@param data vim.api.keyset.create_autocmd.callback_args|{ buf: integer }
 function M.buf_delete(data)
   local bufnr = data.buf
   bufdata.delete_data(bufnr)
 end
 
+---@param data vim.api.keyset.create_autocmd.callback_args|{ buf: integer }
 function M.external_file_change(data)
   M.buf_delete(data)
   M.buf_enter(data)
@@ -217,22 +242,24 @@ function M.enable()
 end
 
 function M.disable()
-  if enabled then
-    enabled = false
-    vim.api.nvim_clear_autocmds { group = "Hlargs" }
+  if not enabled then return end
 
-    for bufnr, _ in pairs(bufdata.get_all()) do
-      bufdata.delete_data(bufnr)
-    end
+  enabled = false
+  vim.api.nvim_clear_autocmds { group = "Hlargs" }
+
+  for bufnr, _ in pairs(bufdata.get_all()) do
+    bufdata.delete_data(bufnr)
   end
 end
 
+---@param bufnr integer
 local function validate_bufnr(bufnr)
   if not vim.api.nvim_buf_is_valid(bufnr) then
     error("Invalid buffer number " .. tostring(bufnr))
   end
 end
 
+---@param bufnr? integer
 function M.enable_buf(bufnr)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
   validate_bufnr(bufnr)
@@ -241,6 +268,7 @@ function M.enable_buf(bufnr)
   M.buf_enter { buf = bufnr }
 end
 
+---@param bufnr? integer
 function M.disable_buf(bufnr)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
   validate_bufnr(bufnr)
@@ -257,9 +285,9 @@ end
 function M.toggle()
   if enabled then
     M.disable()
-  else
-    M.enable()
+    return
   end
+  M.enable()
 end
 
 return M

--- a/lua/hlargs/paint.lua
+++ b/lua/hlargs/paint.lua
@@ -1,11 +1,15 @@
+---@class HlArgs.Paint
+---@overload fun(bufnr: integer, ns: integer, node: TSNode, group: string)
 local M = {}
 local config = require "hlargs.config"
 local colorpalette = require "hlargs.colorpalette"
-local hl_group = "Hlargs"
-M.hl_group = hl_group
+M.hl_group = "Hlargs"
 
 -- Clears a namespace within limits
 -- (or in the entire buffer if limits is nil)
+---@param bufnr integer
+---@param ns integer
+---@param limits? { [1]: integer, [2]: integer }
 function M.clear(bufnr, ns, limits)
   local from, to = 0, -1
   if limits then
@@ -14,16 +18,29 @@ function M.clear(bufnr, ns, limits)
   vim.api.nvim_buf_clear_namespace(bufnr, ns, from, to)
 end
 
+---@param bufnr integer
+---@param ns integer
+---@param start_row integer
+---@param start_col integer
+---@param end_row integer
+---@param end_col integer
+---@param hl_group? string
+---@param priority? integer
+---@return boolean success
+---@return integer mar_id
 function M.set_extmark(bufnr, ns, start_row, start_col, end_row, end_col, hl_group, priority)
   local ok, mark_id = pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, start_row, start_col, {
     end_line = end_row,
     end_col = end_col,
-    hl_group = hl_group,
+    hl_group = hl_group or M.hl_group,
     priority = priority,
   })
   return ok, mark_id
 end
 
+---@param bufnr integer
+---@param extmark { [2]: integer, [3]: integer, [4]: vim.api.keyset.set_extmark }
+---@return string hl_group
 local function get_hl_group(bufnr, extmark)
   if not config.opts.use_colorpalette then return extmark[4].hl_group end
   local start_row, start_col, end_row, end_col =
@@ -38,12 +55,16 @@ local function get_hl_group(bufnr, extmark)
       end_col,
       arg_name[1]
     )
-  else
-    return colorpalette.get_hlgroup_hashed(arg_name[1])
   end
+  return colorpalette.get_hlgroup_hashed(arg_name[1])
 end
 
+---@param bufnr integer
+---@param dst integer
+---@param src integer
+---@param limits? { [1]: integer, [2]: integer }
 function M.combine_nss(bufnr, dst, src, limits)
+  ---@type integer[]|integer, integer[]|integer
   local from, to = 0, -1
   if limits then
     from, to = { limits[1], 0 }, { limits[2], -1 }
@@ -70,6 +91,11 @@ function M.combine_nss(bufnr, dst, src, limits)
 end
 
 setmetatable(M, {
+  ---@param self HlArgs.Paint
+  ---@param bufnr integer
+  ---@param ns integer
+  ---@param node TSNode
+  ---@param group string
   __call = function(self, bufnr, ns, node, group)
     local start_row, start_col, end_row, end_col = node:range()
     M.set_extmark(
@@ -79,7 +105,7 @@ setmetatable(M, {
       start_col,
       end_row,
       end_col,
-      group or hl_group,
+      group or self.hl_group,
       config.opts.hl_priority
     )
   end,

--- a/lua/hlargs/parse.lua
+++ b/lua/hlargs/parse.lua
@@ -7,34 +7,44 @@ local util = require "hlargs.util"
 local ts_get_query
 local ts_get_node_text
 if vim.fn.has "nvim-0.9" == 1 then
-  ts_get_query = ts.query.get
-  ts_get_node_text = ts.get_node_text
+  ts_get_query, ts_get_node_text = ts.query.get, ts.get_node_text
 else
-  ts_get_query = ts.query.get_query
-  ts_get_node_text = ts.query.get_node_text
+  ts_get_query, ts_get_node_text = ts.query.get_query, ts.query.get_node_text
+end
+
+---@param node TSNode
+---@param lang string
+---@param new_from integer
+---@param new_to integer
+---@return integer new_from
+---@return integer new_to
+local function fix_range(node, lang, new_from, new_to)
+  local start_row, _, end_row, _ = util.get_first_function_parent(lang, node):range()
+  if start_row < new_from then new_from = start_row end
+  if end_row > new_to then new_to = end_row end
+  return new_from, new_to
 end
 
 -- If arguments were modified, or if extras.unused_args is enabled,
 -- the whole function has to be reparsed
+---@param lang string
+---@param bufnr integer
+---@param marks_ns integer
+---@param root_node TSNode
+---@param mark integer
 local function fix_mark(lang, bufnr, marks_ns, root_node, mark)
   local orig_from, orig_to = util.get_marks_limits(bufnr, marks_ns, mark)
   local new_from, new_to = orig_from, orig_to
   local arg_query = ts_get_query(lang, "function_arguments")
 
-  local function fix_range(node)
-    local start_row, _, end_row, _ = util.get_first_function_parent(lang, node):range()
-    if start_row < new_from then new_from = start_row end
-    if end_row > new_to then new_to = end_row end
-  end
-
   for _, node in arg_query:iter_captures(root_node, bufnr, orig_from, orig_to + 1) do
-    fix_range(node)
+    new_from, new_to = fix_range(node, lang, new_from, new_to)
     break
   end
   if config.opts.extras.unused_args then
     local var_query = ts_get_query(lang, "variables")
     for _, node in var_query:iter_captures(root_node, bufnr, orig_from, orig_to + 1) do
-      fix_range(node)
+      new_from, new_to = fix_range(node, lang, new_from, new_to)
       break
     end
   end
@@ -46,11 +56,15 @@ local function fix_mark(lang, bufnr, marks_ns, root_node, mark)
   })
 end
 
-function M.get_args(bufnr, lang,  func_node)
+---@param bufnr integer
+---@param lang string
+---@param func_node TSNode
+---@return TSNode[] arg_nodes
+---@return table<string, string> arg_names_set
+function M.get_args(bufnr, lang, func_node)
   if util.has_no_arg_defs(lang) then return {}, {} end
 
   local query = ts_get_query(lang, "function_arguments")
-
   local start_row, _, end_row, _ = func_node:range()
   local arg_names_set, arg_nodes = {}, {}
   for id, node in query:iter_captures(func_node, bufnr, start_row, end_row + 1) do
@@ -67,13 +81,17 @@ function M.get_args(bufnr, lang,  func_node)
   return arg_nodes, arg_names_set
 end
 
+---@param bufnr integer
+---@param lang string
+---@param func_node TSNode
+---@return TSNode[] nodes
 function M.get_body_nodes(bufnr, lang, func_node)
   local query = ts_get_query(lang, "function_body")
 
   local start_row, _, end_row, _ = func_node:range()
   local nodes = {}
   local i = 0
-  for id, node in query:iter_captures(func_node, bufnr, start_row, end_row + 1) do
+  for _, node in query:iter_captures(func_node, bufnr, start_row, end_row + 1) do
     if i == 0 or util.get_first_function_parent(lang, node) == func_node then
       table.insert(nodes, node)
       if not util.is_multi_body_lang(lang) then return nodes end
@@ -83,12 +101,18 @@ function M.get_body_nodes(bufnr, lang, func_node)
   return nodes
 end
 
+---@param bufnr integer
+---@param lang string
+---@param body_nodes TSNode[]
+---@param arg_names_set table<string, string>
+---@param limits? { [1]: integer, [2]: integer }
+---@return TSNode[] usage_nodes
+---@return table<string, boolean> used_args
 function M.get_arg_usages(bufnr, lang, body_nodes, arg_names_set, limits)
   local query = ts_get_query(lang, "variables")
   local has_no_arg_defs = util.has_no_arg_defs(lang)
 
-  local used_args = {}
-  local usages_nodes = {}
+  local used_args, usages_nodes = {}, {} ---@type table<string, boolean>, TSNode[]
   for _, body_node in ipairs(body_nodes) do
     local start_row, _, end_row, _ = body_node:range()
     if limits then
@@ -111,12 +135,18 @@ function M.get_arg_usages(bufnr, lang, body_nodes, arg_names_set, limits)
   return usages_nodes, used_args
 end
 
+---@param bufnr integer
+---@param excluded_names string[]
+---@return fun(node: TSNode): boolean
 local function not_excluded_name(bufnr, excluded_names)
   return function(node)
-    return not vim.tbl_contains(excluded_names, ts_get_node_text(node, bufnr))
+    return not vim.list_contains(excluded_names, ts_get_node_text(node, bufnr))
   end
 end
 
+---@param bufnr integer
+---@param marks_ns integer
+---@param mark integer
 function M.get_nodes_to_paint(bufnr, marks_ns, mark)
   local lang = util.get_lang(bufnr)
 
@@ -138,13 +168,17 @@ function M.get_nodes_to_paint(bufnr, marks_ns, mark)
   end
 end
 
+---@param bufnr integer
+---@param lang string
+---@param tree TSTree
+---@param marks_ns integer
+---@param mark integer
 function M.get_nodes_to_paint_in_tree(bufnr, lang, tree, marks_ns, mark)
   local root = tree:root()
   local has_no_arg_defs = util.has_no_arg_defs(lang)
 
   local query = ts_get_query(lang, "function_definition")
   if query == nil then return end
-
 
   local start_row, _, end_row, _ = root:range()
   if mark then
@@ -153,19 +187,19 @@ function M.get_nodes_to_paint_in_tree(bufnr, lang, tree, marks_ns, mark)
   end
 
   local i = 0
-  for id, node in query:iter_captures(root, bufnr, start_row, end_row) do
+  for _, node in query:iter_captures(root, bufnr, start_row, end_row) do
     i = i + 1
     if
       config.opts.performance.max_iterations > 0 and i > config.opts.performance.max_iterations
     then
       return
     end
-    local name = query.captures[id] -- name of the capture
+    -- local name = query.captures[id] -- name of the capture
     local arg_nodes, arg_names_set = M.get_args(bufnr, lang, node)
     local usages_nodes, used_args = {}, {}
     if config.opts.paint_arg_usages and (#arg_nodes > 0 or has_no_arg_defs) then
       local body_nodes = M.get_body_nodes(bufnr, lang, node)
-      local limits = nil
+      local limits = nil ---@type nil|{ [1]: integer, [2]: integer }
       if mark then
         local from, to = util.get_marks_limits(bufnr, marks_ns, mark)
         limits = { from, to }

--- a/lua/hlargs/util.lua
+++ b/lua/hlargs/util.lua
@@ -1,8 +1,9 @@
+---@class HlArgs.Util
 local M = {}
 
 local new_lang_api = vim.treesitter.language.register ~= nil
 
-local ignored_field_names = {
+local ignored_field_names = { ---@type table<string, table<string, string[]>>
   c_sharp = {
     member_access_expression = { "name" },
   },
@@ -26,19 +27,23 @@ local ignored_field_names = {
   },
 }
 
+---@param node TSNode
+---@return boolean is_node
 local function julia_is_function_node(node)
   local node_type = node:type()
-  if vim.tbl_contains({ "function_definition", "function_expression", "do_clause" }, node_type) then
+  if
+    vim.list_contains({ "function_definition", "function_expression", "do_clause" }, node_type)
+  then
     return true
   end
-  if node_type == "assignment_expression" then
-    if node:child(0):type() == "call_expression" then return true end
+  if node_type == "assignment_expression" and node:child(0):type() == "call_expression" then
+    return true
   end
   return false
 end
 
 -- stylua: ignore
-local function_or_catch_node_validators = {
+local function_or_catch_node_validators = { ---@type table<string, string[]|fun(node: TSNode): is_node: boolean>
   astro = { },
   bash = { "function_definition" },
   c = { "function_definition" },
@@ -66,36 +71,41 @@ local function_or_catch_node_validators = {
   zig = { "function_declaration" },
 }
 
-local multi_body_langs = { "ruby", "cpp", "cuda", "julia", "solidity" }
-local no_arg_defs_langs = { "bash" }
+local multi_body_langs = { "ruby", "cpp", "cuda", "julia", "solidity" } ---@type string[]
+local no_arg_defs_langs = { "bash" } ---@type string[]
 
+---@param filetype string
+---@param node TSNode
+---@return boolean ignored
 function M.ignore_node(filetype, node)
-  if ignored_field_names[filetype] and node:parent() then
-    for ch, field_name in node:parent():iter_children() do
-      if ch == node then
-        local ignored_list
-        if ignored_field_names[filetype][node:parent():type()] then
-          ignored_list = ignored_field_names[filetype][node:parent():type()]
-        else
-          ignored_list = ignored_field_names[filetype]["_"] or {}
-        end
-        return vim.tbl_contains(ignored_list, field_name) or vim.tbl_contains(ignored_list, "_")
+  if not (ignored_field_names[filetype] or node:parent()) then return false end
+  for ch, field_name in node:parent():iter_children() do
+    if ch == node then
+      local ignored_list ---@type table<string, table<string, string[]>>
+      if ignored_field_names[filetype][node:parent():type()] then
+        ignored_list = ignored_field_names[filetype][node:parent():type()]
+      else
+        ignored_list = ignored_field_names[filetype]["_"] or {}
       end
+      return vim.list_contains(ignored_list, field_name) or vim.list_contains(ignored_list, "_")
     end
   end
   return false
 end
 
+---@param filetype string
+---@param node TSNode
+---@return boolean fun_or_catch
 local function is_function_or_catch_node(filetype, node)
   local validator = function_or_catch_node_validators[filetype]
-  if type(validator) == "table" then
-    return vim.tbl_contains(validator, node:type())
-  elseif type(validator) == "function" then
-    return validator(node)
-  end
+  if type(validator) == "table" then return vim.list_contains(validator, node:type()) end
+  if type(validator) == "function" then return validator(node) end
   return false
 end
 
+---@param filetype string
+---@param node TSNode
+---@return TSNode node
 function M.get_first_function_parent(filetype, node)
   while node and not is_function_or_catch_node(filetype, node) do
     node = node:parent()
@@ -105,14 +115,23 @@ end
 
 -- Some languages (ejem, Ruby) don't have a single body node,
 -- but instead everything after the parameters is body
+---@param lang string
+---@return boolean is_multi_body
 function M.is_multi_body_lang(lang)
-  return vim.tbl_contains(multi_body_langs, lang)
+  return vim.list_contains(multi_body_langs, lang)
 end
 
+---@param lang string
+---@return boolean no_args_defs
 function M.has_no_arg_defs(lang)
-  return vim.tbl_contains(no_arg_defs_langs, lang)
+  return vim.list_contains(no_arg_defs_langs, lang)
 end
 
+---@param bufnr integer
+---@param marks_ns integer
+---@param extmark integer
+---@return integer row
+---@return integer end_row
 function M.get_marks_limits(bufnr, marks_ns, extmark)
   local mark_data = vim.api.nvim_buf_get_extmark_by_id(bufnr, marks_ns, extmark, { details = true })
   return mark_data[1], mark_data[3].end_row
@@ -120,7 +139,12 @@ end
 
 -- Merges overlapping (or non overlapping, but
 -- separated by up to a line) ranges in a list
+---@param bufnr integer
+---@param marks_ns integer
+---@param ranges integer[]
+---@return integer[] merged_ranges
 function M.merge_ranges(bufnr, marks_ns, ranges)
+  ---@type integer[]
   ranges = vim.tbl_filter(function(r)
     return r ~= nil
   end, ranges)
@@ -128,13 +152,11 @@ function M.merge_ranges(bufnr, marks_ns, ranges)
 
   -- Sort by ranges' start position
   table.sort(ranges, function(a, b)
-    a = M.get_marks_limits(bufnr, marks_ns, a)
-    b = M.get_marks_limits(bufnr, marks_ns, b)
-    return a < b
+    return M.get_marks_limits(bufnr, marks_ns, a) < M.get_marks_limits(bufnr, marks_ns, b)
   end)
 
   local last_added = ranges[1]
-  local merged_ranges = { last_added }
+  local merged_ranges = { last_added } ---@type integer[]
   for i = 2, #ranges do
     local next = ranges[i]
     local last_start, last_end = M.get_marks_limits(bufnr, marks_ns, last_added)
@@ -159,19 +181,22 @@ function M.merge_ranges(bufnr, marks_ns, ranges)
   return merged_ranges
 end
 
+---@param bufnr integer
+---@return string|nil lang
 function M.get_lang(bufnr)
   local filetype = vim.fn.getbufvar(bufnr, "&filetype")
-  if new_lang_api then
-    return vim.treesitter.language.get_lang(filetype)
-  else
-    return require("nvim-treesitter.parsers").ft_to_lang(filetype)
-  end
+  if new_lang_api then return vim.treesitter.language.get_lang(filetype) end
+  return require("nvim-treesitter.parsers").ft_to_lang(filetype)
 end
 
+---@param lang string
+---@return boolean supported
 function M.is_supported(lang)
   return function_or_catch_node_validators[lang] ~= nil
 end
 
+---@param node TSNode
+---@param bufnr integer
 function M.print_node_text(node, bufnr)
   local text = vim.treesitter.query.get_node_text(node, bufnr)
   for line = 1, #text do
@@ -179,6 +204,10 @@ function M.print_node_text(node, bufnr)
   end
 end
 
+---@param pred fun(value: any): boolean
+---@param tbl table<any, any>
+---@return any[]
+---@return any[]
 function M.tbl_spit_by(pred, tbl)
   return vim.tbl_filter(pred, tbl),
     vim.tbl_filter(function(entry)


### PR DESCRIPTION
## Description

I've done a ton of fixes/enhancements. Sorry for the huge amount of changes but most of them are related to LuaLS annotations:

- Add correct LuaLS annotations
- Replace `vim.loop` with `uv = vim.uv or vim.loop` (`vim.loop is deprecated in newer versions)
- Improved conditionals and return statements
- Made function notation consistent
- Fixed typos

Any feedback please let me know!