### PR TITLE
Add support for Swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Currently these languages are supported
 - rust
 - scala
 - solidity
+- swift
 - tsx (react)
 - typescript
 - vim

--- a/lua/hlargs/util.lua
+++ b/lua/hlargs/util.lua
@@ -21,6 +21,10 @@ local ignored_field_names = {
     field_access = { "field" },
   },
   scala = { field_expression = { "field" } },
+  swift = {
+    navigation_suffix = { "suffix" },
+    value_argument = { "name", "reference_specifier" },
+  },
   vim = {
     scoped_identifier = { "_" },
   },
@@ -58,7 +62,8 @@ local function_or_catch_node_validators = {
   r = { "function_definition" },
   ruby = { "method", "lambda", "block", "do_block", "rescue" },
   rust = { "function_item" },
-	scala = { 'lambda_expression', 'function_definition' },
+  scala = { 'lambda_expression', 'function_definition' },
+  swift = { "function_declaration", "init_declaration", "deinit_declaration", "lambda_literal", "catch_block" },
   solidity = { "function_declaration", "function_definition", "constructor_definition", "modifier_definition" },
   tsx = { "function_declaration", "function_expression", "method_definition", "arrow_function", "catch_clause" },
   typescript = { "function_declaration", "function_expression", "method_definition", "arrow_function", "catch_clause" },

--- a/queries/swift/function_arguments.scm
+++ b/queries/swift/function_arguments.scm
@@ -1,0 +1,9 @@
+(parameter
+  name: (simple_identifier) @argname
+  (#not-eq? @argname "_"))
+(lambda_parameter
+  name: (simple_identifier) @argname
+  (#not-eq? @argname "_"))
+(catch_block
+  error: (pattern
+    (simple_identifier) @catch))

--- a/queries/swift/function_body.scm
+++ b/queries/swift/function_body.scm
@@ -1,0 +1,10 @@
+(function_declaration
+  body: (function_body) @body)
+(init_declaration
+  body: (function_body) @body)
+(deinit_declaration
+  body: (function_body) @body)
+(lambda_literal
+  (statements) @body)
+(catch_block
+  (statements) @body)

--- a/queries/swift/function_definition.scm
+++ b/queries/swift/function_definition.scm
@@ -1,0 +1,5 @@
+(function_declaration) @fn
+(init_declaration) @fn
+(deinit_declaration) @fn
+(lambda_literal) @fn
+(catch_block) @catch

--- a/queries/swift/variables.scm
+++ b/queries/swift/variables.scm
@@ -1,0 +1,1 @@
+(simple_identifier) @var

--- a/testfiles/test.swift
+++ b/testfiles/test.swift
@@ -1,0 +1,33 @@
+struct Binding<T> {}
+
+enum Forms {
+    struct Field {}
+}
+
+final class App {
+    init(presentRegistration: Binding<Bool>, fields: [Forms.Field], onComplete: @escaping () -> Void) {
+        _ = presentRegistration
+        _ = fields
+        onComplete()
+    }
+
+    func createRequest(endpoint: String, subpath: String? = nil, method: String? = nil) -> String? {
+        let path = subpath ?? ""
+        let verb = method ?? "GET"
+        return endpoint + path + verb
+    }
+
+    func update(_ value: Int, with newValue: Int) -> Int {
+        return value + newValue
+    }
+
+    func map(_ values: [Int], using transform: (Int) -> Int) -> [Int] {
+        return values.map { item in
+            transform(item)
+        }
+    }
+}
+
+func topLevel(label: String) -> String {
+    return label
+}


### PR DESCRIPTION
This PR adds support for the Swift programming language.
When a function has both an external and internal name, it will only highlight the internal name, to make it more clear what is actually used and where.

Full disclosure, I piggy-backed on `opencode` to make these changes.